### PR TITLE
feat(auth): set up authentication service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,15 @@ notifications:
   email: false
 env:
   global:
-  - CC_TEST_REPORTER_ID=bb88b704d3c35b991446df360daeeb9d3db2affaa204eb689c42e5b4bb71d3c1
+    - CC_TEST_REPORTER_ID=bb88b704d3c35b991446df360daeeb9d3db2affaa204eb689c42e5b4bb71d3c1
+  matrix:
+    - TEST_DIRECTORY="api-gateway"
+    - TEST_DIRECTORY="authservice"
 before_script:
+  - cd $TEST_DIRECTORY
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-  - cd api-gateway
   - npm install
 script:
   - npm run test

--- a/api-gateway/src/api-server.js
+++ b/api-gateway/src/api-server.js
@@ -8,11 +8,15 @@ const PORT = process.env.PORT || 8080;
 
 const apiServer = gateway({
   middleware: [
-    cors,
-    helmet
+    cors(),
+    helmet()
   ],
   routes: [
-    
+    {
+      prefix: '/auth',
+      target: 'http://localhost:3000',
+      methods: ['GET', 'POST']
+    }
   ]
 });
 

--- a/authservice/.babelrc
+++ b/authservice/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "10"
+        }
+      }
+    ]
+  ]
+}

--- a/authservice/.codeclimate.yml
+++ b/authservice/.codeclimate.yml
@@ -1,0 +1,10 @@
+version: "2"
+exclude_patterns:
+  - "src/database/"
+  - "src/models/"
+  - "**/test/"
+  - "./src/utils/emailTemplates/confirmAccountTemplate.js"
+  - "./src/utils/emailTemplates/passwordRecoveryTemplate.js"
+  - "./src/utils/emailTemplates/tripRequestTemplate.js"
+  - "./src/utils/emailTemplates/tripFeedbackTemplate.js"
+  - "./src/utils/emailTemplatesFunction.js"

--- a/authservice/.eslintignore
+++ b/authservice/.eslintignore
@@ -1,0 +1,7 @@
+node_modules/
+npm-debug.log
+.vscode/**
+.nyc_output/
+coverage
+src/database/
+src/models

--- a/authservice/.eslintrc
+++ b/authservice/.eslintrc
@@ -1,0 +1,45 @@
+{
+  "root": true,
+  "extends": "airbnb-base",
+  "env": {
+    "node": true,
+    "es6": true,
+    "mocha": true
+  },
+  "rules": {
+    "one-var": 0,
+    "one-var-declaration-per-line": 0,
+    "new-cap": 0,
+    "linebreak-style":0,
+    "consistent-return": 0,
+    "no-param-reassign": 0,
+    "comma-dangle": 0,
+    "import/no-extraneous-dependencies": 0,
+    "no-undef":0,
+    "curly": ["error", "multi-line"],
+    "import/no-unresolved": [2, { "commonjs": true }],
+    "no-shadow": ["error", { "allow": ["req", "res", "err"] }],
+    "valid-jsdoc": [
+      "error",
+      {
+        "requireReturn": true,
+        "requireReturnType": true,
+        "requireParamDescription": false,
+        "requireReturnDescription": true
+      }
+    ],
+    "require-jsdoc": [
+      "error",
+      {
+        "require": {
+          "FunctionDeclaration": true,
+          "MethodDefinition": true,
+          "ClassDeclaration": true
+        }
+      }
+    ],
+    "no-trailing-spaces": ["error", { "skipBlankLines": true }],
+    "no-unused-vars": ["error", { "varsIgnorePattern": "[iI]gnored" }],
+    "no-underscore-dangle": ["error", { "allowAfterThis": true }]
+  }
+}

--- a/authservice/package.json
+++ b/authservice/package.json
@@ -1,21 +1,18 @@
 {
-  "name": "api-gateway",
+  "name": "authservice",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "nyc --reporter=html --reporter=text mocha src/test --timeout 10000 --require @babel/register --recursive --exit || true",
-    "start": "nodemon --exec babel-node ./src/api-server.js"
+    "test": "nyc --reporter=html --reporter=text mocha src/test/*.spec.js --timeout 10000 --require @babel/register --recursive --exit || true",
+    "start": "nodemon --exec babel-node ./src/index.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "cors": "^2.8.5",
-    "dotenv": "^8.1.0",
-    "express-validator": "^6.2.0",
-    "fast-gateway": "^1.3.8",
-    "helmet": "^3.21.1",
+    "bcrypt": "^3.0.6",
+    "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {

--- a/authservice/src/index.js
+++ b/authservice/src/index.js
@@ -1,0 +1,10 @@
+import express from 'express';
+
+const app = express();
+const PORT = 3000;
+
+app.get('/', (req, res) => res.status(403).json({ status: 403, message: 'You cannot query this route'}));
+
+app.listen(PORT, () => console.log(`Auth service lisening at port ${PORT}`));
+
+export default app;

--- a/authservice/src/test/authservice.spec.js
+++ b/authservice/src/test/authservice.spec.js
@@ -1,0 +1,18 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../index';
+
+
+chai.use(chaiHttp);
+chai.should();
+
+describe('Auth service', () => {
+  describe('Index route', () => {
+    it('should return a forbidden response for a get query to the index route', async () => {
+      const response = await chai.request(server).get('/');
+      response.body.should.have.status(403);
+      response.body.should.have.property('status', 403);
+      response.body.should.have.property('message', 'You cannot query this route');
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?
This PR sets up the authentication service for the kabu-kabu microservices app

## What major activities were carried out?
- create a new app folder and download the neccessary packages (express, jsonwebtoken, bcrypt)
- install dev dependencies (babel, eslint, nyc, mocha, lcov-reporter)
- customize each of the development tools
- create an app with an index route to test
- write test to confirm app working

## How can this be manually tested?
- Clone repo by running `git clone https://github.com/darasimiolaifa/kabu-kabu-microservice.git`
- Run `git fetch ch-setup-authentication-service-169062061`
- Run the command `cd kabu-kabu-microservice/authservice`
- Run `npm install`
- Run `npm start`
- In Postman, send a `GET` request to this url `http://localhost:3000`, you should get the following response:
```json
  {
    "status": 403,
    "message": "You cannot query this route."
  }
```

## Any background information to provide?
- It is important to cd into the folder that holds the app for the gateway code, as this is built with the microservices architecture where each service is a standalone app. Else the npm scripts will throw an error.

PT story link: [#169062047](https://www.pivotaltracker.com/story/show/169062061)